### PR TITLE
Tweak dedication

### DIFF
--- a/src/epub/text/dedication.xhtml
+++ b/src/epub/text/dedication.xhtml
@@ -11,7 +11,7 @@
 			to<br/>
 			<span>the officers</span><br/>
 			of the<br/>
-			4th <span>(Queen’s Own) Hussars</span><br/>
+			<span>4</span>th <span>(Queen’s Own) Hussars</span><br/>
 			in whose company the author lived<br/>
 			for four happy years</p>
 		</section>


### PR DESCRIPTION
Because small caps numerals are a thing.

Put the 4 in "4th" in a span to make sure it's not small-capped.